### PR TITLE
Slack bot interactivity with buttons

### DIFF
--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/PendingReportState.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/PendingReportState.java
@@ -1,0 +1,26 @@
+package com.innovactions.incident.adapter.inbound.slack;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class PendingReportState {
+
+    private final Map<String, Boolean> userIdToPending = new ConcurrentHashMap<>();
+
+    public void markPending(String userId) {
+        userIdToPending.put(userId, Boolean.TRUE);
+    }
+
+    public boolean isPending(String userId) {
+        return userIdToPending.containsKey(userId);
+    }
+
+    public void clear(String userId) {
+        userIdToPending.remove(userId);
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackController.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.concurrent.CompletableFuture;
 
 @RestController
-@RequestMapping("/slack/events")
+@RequestMapping("/slack/manager")
 public class SlackController {
 
     private final IncidentInboundPort incidentInboundPort;

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerActions.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerActions.java
@@ -1,0 +1,48 @@
+package com.innovactions.incident.adapter.inbound.slack;
+
+import com.innovactions.incident.port.outbound.BotMessagingPort;
+import com.innovactions.incident.adapter.outbound.IncidentActionBlocks;
+import com.innovactions.incident.port.outbound.ChannelAdministrationPort;
+import com.slack.api.bolt.App;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackManagerActions {
+
+    private final String botTokenB;
+    private final ChannelAdministrationPort channelAdministrationPort;
+    private final BotMessagingPort managerBotMessagingPort;
+
+    public void register(App managerApp) {
+        managerApp.blockAction("ack_incident", (req, ctx) -> {
+            String user = req.getPayload().getUser().getId();
+            String channel = req.getPayload().getChannel().getId();
+            managerBotMessagingPort.sendMessage(channel, "👨‍💻 <@" + user + "> acknowledged and is working on this incident.");
+            return ctx.ack();
+        });
+
+        managerApp.blockAction("dismiss_incident", (req, ctx) -> {
+            String user = req.getPayload().getUser().getId();
+            String channel = req.getPayload().getChannel().getId();
+            managerBotMessagingPort.sendMessage(channel, "🚫 Incident dismissed by <@" + user + ">.");
+            // Post a follow-up with a "Leave Channel" button
+            managerBotMessagingPort.sendMessageWithBlocks(
+                    channel,
+                    "❓ Do you want to leave the channel?",
+                    IncidentActionBlocks.leaveChannelButton()
+            );
+            return ctx.ack();
+        });
+
+        managerApp.blockAction("leave_channel", (req, ctx) -> {
+            String user = req.getPayload().getUser().getId();
+            String channel = req.getPayload().getChannel().getId();
+            channelAdministrationPort.kickUserFromChannel(channel, user);
+            return ctx.ack();
+        });
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
@@ -1,0 +1,89 @@
+package com.innovactions.incident.adapter.inbound.slack;
+
+import com.innovactions.incident.application.command.CreateIncidentCommand;
+import com.innovactions.incident.adapter.outbound.IncidentActionBlocks;
+import com.innovactions.incident.port.inbound.IncidentInboundPort;
+import com.innovactions.incident.port.outbound.BotMessagingPort;
+import com.slack.api.bolt.App;
+import com.slack.api.model.event.MessageEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+public class SlackReporterFlow {
+
+    private final PendingReportState pendingReportState;
+    private final IncidentInboundPort incidentInboundPort;
+    private final BotMessagingPort reporterBotMessagingPort;
+
+    public void register(App app) {
+        // report_bug --> mark pending and prompt for details
+        app.blockAction("report_bug", (req, ctx) -> {
+            String userId = req.getPayload().getUser().getId();
+            pendingReportState.markPending(userId);
+            reporterBotMessagingPort.sendMessage(userId, "<@" + userId + ">, please describe the bug in detail.");
+            return ctx.ack();
+        });
+
+        // check_status --> check status of current incident that is assigned to the user
+        app.blockAction("check_status", (req, ctx) -> {
+            String userId = req.getPayload().getUser().getId();
+            reporterBotMessagingPort.sendMessage(userId, "<@" + userId + ">, status check feature is not implemented yet.");
+            // TODO
+            return ctx.ack();
+        });
+
+        // if pending, treat message as incident details, otherwise show actions
+        app.event(MessageEvent.class, (payload, ctx) -> {
+            var event = payload.getEvent();
+            String channelType = event.getChannelType();
+
+            if (event.getBotId() != null) {
+                return ctx.ack();
+            }
+            if (!"im".equals(channelType)) {
+                return ctx.ack();
+            }
+
+            String userId = event.getUser();
+            String text = event.getText() == null ? "" : event.getText();
+
+            if (pendingReportState.isPending(userId)) {
+                reporterBotMessagingPort.sendMessage(userId, "Thanks! Processing your report...");
+                CompletableFuture.runAsync(() -> {
+                    try {
+                        String reporterName = reporterBotMessagingPort.resolveUserRealName(userId);
+
+                        CreateIncidentCommand command = new CreateIncidentCommand(
+                                userId,
+                                reporterName,
+                                text,
+                                Instant.now()
+                        );
+                        incidentInboundPort.handle(command);
+                        reporterBotMessagingPort.sendMessage(userId, "Bug assigned to an available developer. We will notify you when it's resolved.");
+                    } catch (Exception e) {
+                        // pass
+                    } finally {
+                        pendingReportState.clear(userId);
+                    }
+                });
+            } else {
+                // is there a better way to format json in java?
+                reporterBotMessagingPort.sendMessageWithBlocks(
+                        event.getChannel(),
+                        "Hi, what would you like to do?",
+                        IncidentActionBlocks.reporterButtons()
+                );
+            }
+
+            return ctx.ack();
+        });
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/adapter/outbound/IncidentActionBlocks.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/IncidentActionBlocks.java
@@ -1,0 +1,66 @@
+package com.innovactions.incident.adapter.outbound;
+
+public final class IncidentActionBlocks {
+
+    private IncidentActionBlocks() {}
+
+    public static String reporterButtons() {
+        return "[" +
+                "{\n" +
+                "  \"type\": \"actions\",\n" +
+                "  \"elements\": [\n" +
+                "    {\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"text\": { \"type\": \"plain_text\", \"text\": \"🐞 Report a bug\" },\n" +
+                "      \"action_id\": \"report_bug\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"text\": { \"type\": \"plain_text\", \"text\": \"📊 Check status\" },\n" +
+                "      \"action_id\": \"check_status\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n" +
+                "]";
+    }
+
+    public static String acknowledgeDismissButtons() {
+        return "[" +
+                "{\n" +
+                "  \"type\": \"actions\",\n" +
+                "  \"elements\": [\n" +
+                "    {\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"text\": { \"type\": \"plain_text\", \"text\": \"✅ Acknowledge\" },\n" +
+                "      \"style\": \"primary\",\n" +
+                "      \"action_id\": \"ack_incident\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"text\": { \"type\": \"plain_text\", \"text\": \"❌ Dismiss\" },\n" +
+                "      \"style\": \"danger\",\n" +
+                "      \"action_id\": \"dismiss_incident\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n" +
+                "]";
+    }
+
+    public static String leaveChannelButton() {
+        return "[" +
+                "{\n" +
+                "  \"type\": \"actions\",\n" +
+                "  \"elements\": [\n" +
+                "    {\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"text\": { \"type\": \"plain_text\", \"text\": \"Leave Channel\" },\n" +
+                "      \"style\": \"danger\",\n" +
+                "      \"action_id\": \"leave_channel\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n" +
+                "]";
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/adapter/outbound/SlackBotMessagingAdapter.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/SlackBotMessagingAdapter.java
@@ -1,0 +1,73 @@
+package com.innovactions.incident.adapter.outbound;
+
+import com.innovactions.incident.port.outbound.BotMessagingPort;
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.users.UsersInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class SlackBotMessagingAdapter implements BotMessagingPort {
+
+    private final String botToken;
+
+    public SlackBotMessagingAdapter(String botToken) {
+        this.botToken = botToken;
+    }
+
+    @Override
+    public void sendMessage(String channelId, String text) {
+        sendMessageInternal(channelId, text, null);
+    }
+
+    @Override
+    public void sendMessageWithBlocks(String channelId, String text, String blocksJson) {
+        sendMessageInternal(channelId, text, blocksJson);
+    }
+
+    private void sendMessageInternal(String channelId, String text, String blocksJson) {
+        try {
+            ChatPostMessageResponse response;
+            if (blocksJson != null) {
+                response = Slack.getInstance().methods(botToken)
+                        .chatPostMessage(req -> req
+                                .channel(channelId)
+                                .text(text)
+                                .blocksAsString(blocksJson)
+                        );
+            } else {
+                response = Slack.getInstance().methods(botToken)
+                        .chatPostMessage(req -> req
+                                .channel(channelId)
+                                .text(text)
+                        );
+            }
+            
+            if (!response.isOk()) {
+                log.warn("Failed to send message to {}: {}", channelId, response.getError());
+            } else {
+                log.info("Message sent to {}: {}", channelId, text);
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Error sending message to {}: {}", channelId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String resolveUserRealName(String userId) {
+        try {
+            UsersInfoResponse info = Slack.getInstance().methods(botToken).usersInfo(r -> r.user(userId));
+            if (info.isOk() && info.getUser() != null && info.getUser().getProfile() != null) {
+                return info.getUser().getProfile().getRealName();
+            }
+        } catch (IOException | SlackApiException e) {
+            log.warn("Slack API error resolving user info for {}: {}", userId, e.getMessage());
+        }
+        return userId;
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/adapter/outbound/SlackBroadcaster.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/SlackBroadcaster.java
@@ -2,8 +2,11 @@ package com.innovactions.incident.adapter.outbound;
 
 import com.innovactions.incident.domain.model.Incident;
 import com.innovactions.incident.domain.model.Severity;
+import com.innovactions.incident.adapter.outbound.IncidentActionBlocks;
 import com.innovactions.incident.domain.service.ChannelNameGenerator;
 import com.innovactions.incident.port.outbound.IncidentBroadcasterPort;
+import com.innovactions.incident.port.outbound.ChannelAdministrationPort;
+import com.innovactions.incident.port.outbound.BotMessagingPort;
 import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.conversations.ConversationsCreateResponse;
@@ -22,62 +25,36 @@ public class SlackBroadcaster implements IncidentBroadcasterPort {
     private final String botToken;
     private final String developerUserId;
     private final ChannelNameGenerator channelNameGenerator;
+    private final BotMessagingPort managerBotMessagingPort;
+    private final ChannelAdministrationPort channelAdministrationPort;
 
     @Override
     public void broadcast(Incident incident) {
-        try {
-            // generate channel name based on severity and timestamp
-            String channelName = channelNameGenerator.generateChannelName(incident.getSeverity());
-            
-            // create new channel in workspace B
-            ConversationsCreateResponse createResponse = Slack.getInstance().methods(botToken)
-                    .conversationsCreate(req -> req
-                            .name(channelName)
-                            .isPrivate(false)
-                    );
-            
-            if (!createResponse.isOk()) {
-                log.error("Failed to create channel for incident [{}]: {}", incident.getId(), createResponse.getError());
-                return;
-            }
-            
-            String channelId = createResponse.getChannel().getId();
-            log.info("Created channel {} for incident: {}", channelName, incident.getId());
-            
-            // set channel topic with reporter information
-            ConversationsSetTopicResponse topicResponse = Slack.getInstance().methods(botToken)
-                    .conversationsSetTopic(req -> req
-                            .channel(channelId)
-                            .topic("reporterid:" + incident.getReporterId() + "_slack")
-                    );
-            
-            if (!topicResponse.isOk()) {
-                log.warn("Failed to set topic for channel {}: {}", channelName, topicResponse.getError());
-            }
-            
-            // invite developer to the channel
-            ConversationsInviteResponse inviteResponse = Slack.getInstance().methods(botToken)
-                    .conversationsInvite(req -> req
-                            .channel(channelId)
-                            .users(List.of(developerUserId))
-                    );
-            
-            if (!inviteResponse.isOk()) {
-                log.warn("Failed to invite developer to channel {}: {}", channelName, inviteResponse.getError());
-            } else {
-                log.info("Invited developer {} to channel {}", developerUserId, channelName);
-            }
-            
-            // post incident summary to the new channel
-            Slack.getInstance().methods(botToken).chatPostMessage(req -> req
-                    .channel(channelId)
-                    .text(incident.summary())
-            );
-            
-            log.info("Incident broadcasted to new channel {}: {}", channelName, incident.getId());
-            
-        } catch (IOException | SlackApiException e) {
-            log.error("Failed to broadcast incident [{}] to Slack: {}", incident.getId(), e.getMessage(), e);
+        // generate channel name based on severity and timestamp
+        String channelName = channelNameGenerator.generateChannelName(incident.getSeverity());
+
+        // create new channel in workspace B
+        String channelId = channelAdministrationPort.createPublicChannel(channelName);
+        if (channelId == null) {
+            log.error("Failed to create channel for incident [{}]", incident.getId());
+            return;
         }
+        log.info("Created channel {} for incident: {}", channelName, incident.getId());
+
+        // set channel topic with reporter information
+        channelAdministrationPort.setChannelTopic(channelId, "reporterid:" + incident.getReporterId() + "_slack");
+
+        // invite developer to the channel
+        channelAdministrationPort.inviteUsers(channelId, List.of(developerUserId));
+        log.info("Invited developer {} to channel {}", developerUserId, channelName);
+
+        // post incident summary with actions to the new channel
+        managerBotMessagingPort.sendMessageWithBlocks(
+                channelId,
+                incident.summary(),
+                IncidentActionBlocks.acknowledgeDismissButtons()
+        );
+
+        log.info("Incident broadcasted to new channel {}: {}", channelName, incident.getId());
     }
 }

--- a/src/main/java/com/innovactions/incident/adapter/outbound/SlackChannelAdministrationAdapter.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/SlackChannelAdministrationAdapter.java
@@ -1,0 +1,93 @@
+package com.innovactions.incident.adapter.outbound;
+
+import com.innovactions.incident.port.outbound.ChannelAdministrationPort;
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.conversations.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class SlackChannelAdministrationAdapter implements ChannelAdministrationPort {
+
+    private final String botToken;
+
+    public SlackChannelAdministrationAdapter(String botToken) {
+        this.botToken = botToken;
+    }
+
+    @Override
+    public String createPublicChannel(String name) {
+        try {
+            ConversationsCreateResponse res = Slack.getInstance().methods(botToken)
+                    .conversationsCreate(req -> req.name(name).isPrivate(false));
+            if (!res.isOk()) {
+                log.error("Failed to create channel {}: {}", name, res.getError());
+                return null;
+            }
+            return res.getChannel().getId();
+        } catch (IOException | SlackApiException e) {
+            log.error("Error creating channel {}: {}", name, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Override
+    public void setChannelTopic(String channelId, String topic) {
+        try {
+            ConversationsSetTopicResponse res = Slack.getInstance().methods(botToken)
+                    .conversationsSetTopic(req -> req.channel(channelId).topic(topic));
+            if (!res.isOk()) {
+                log.warn("Failed to set topic for {}: {}", channelId, res.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Error setting topic for {}: {}", channelId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void inviteUsers(String channelId, List<String> userIds) {
+        try {
+            ConversationsInviteResponse res = Slack.getInstance().methods(botToken)
+                    .conversationsInvite(req -> req.channel(channelId).users(userIds));
+            if (!res.isOk()) {
+                log.warn("Failed to invite users to {}: {}", channelId, res.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Error inviting users to {}: {}", channelId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void kickUserFromChannel(String channelId, String userId) {
+        try {
+            ConversationsKickResponse res = Slack.getInstance().methods(botToken)
+                    .conversationsKick(req -> req.channel(channelId).user(userId));
+            if (!res.isOk()) {
+                log.warn("Failed to kick {} from {}: {}", userId, channelId, res.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Error kicking {} from {}: {}", userId, channelId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<String> listMembers(String channelId) {
+        try {
+            ConversationsMembersResponse res = Slack.getInstance().methods(botToken)
+                    .conversationsMembers(req -> req.channel(channelId));
+            if (!res.isOk()) {
+                log.warn("Failed to list members for {}: {}", channelId, res.getError());
+                return List.of();
+            }
+            return res.getMembers();
+        } catch (IOException | SlackApiException e) {
+            log.error("Error listing members for {}: {}", channelId, e.getMessage(), e);
+            return List.of();
+        }
+    }
+}
+
+

--- a/src/main/java/com/innovactions/incident/config/SecurityConfig.java
+++ b/src/main/java/com/innovactions/incident/config/SecurityConfig.java
@@ -14,7 +14,12 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF off
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/slack/events", "/slack/events/close_incident").permitAll()
+                        .requestMatchers(
+                            "/slack/events", 
+                            "/slack/reporter", 
+                            "/slack/manager", 
+                            "/slack/manager/close_incident"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(httpBasic -> {

--- a/src/main/java/com/innovactions/incident/config/SlackConfig.java
+++ b/src/main/java/com/innovactions/incident/config/SlackConfig.java
@@ -1,12 +1,19 @@
 package com.innovactions.incident.config;
 
+import com.innovactions.incident.adapter.inbound.slack.SlackReporterFlow;
+import com.innovactions.incident.adapter.inbound.slack.SlackManagerActions;
 import com.innovactions.incident.adapter.inbound.slack.SlackCloseIncident;
 import com.innovactions.incident.adapter.inbound.slack.SlackCreateIncident;
+import com.innovactions.incident.adapter.inbound.slack.SlackReporterFlow;
 import com.innovactions.incident.adapter.outbound.SlackBroadcaster;
+import com.innovactions.incident.adapter.outbound.SlackBotMessagingAdapter;
+import com.innovactions.incident.adapter.outbound.SlackChannelAdministrationAdapter;
 import com.innovactions.incident.adapter.outbound.SlackIncidentClosureBroadcaster;
 import com.innovactions.incident.port.inbound.IncidentInboundPort;
 import com.innovactions.incident.port.outbound.IncidentBroadcasterPort;
 import com.innovactions.incident.port.outbound.IncidentClosurePort;
+import com.innovactions.incident.port.outbound.BotMessagingPort;
+import com.innovactions.incident.port.outbound.ChannelAdministrationPort;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.jakarta_servlet.SlackAppServlet;
@@ -18,6 +25,7 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
 @Configuration
@@ -25,26 +33,30 @@ public class SlackConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SlackConfig.class);
 
-    @Value("${slack.signingSecret}")
-    private String signingSecret;
+    @Value("${slack.signingSecretA}")
+    private String signingSecretA;
+
+    @Value("${slack.signingSecretB}")
+    private String signingSecretB;
 
     @Value("${slack.botTokenA}")
     private String botTokenA;
 
+    @Value("${slack.botTokenB}")
+    private String botTokenB;
+
+    // Reporter App (Bot A): handles user reports via @mentions
     @Bean
-    public App slackApp(SlackCreateIncident slackInboundAdapter, SlackCloseIncident slackCloseIncident) {
+    public App reporterSlackApp(SlackCreateIncident slackInboundAdapter, SlackReporterFlow slackReporterFlow) {
         var appConfig = AppConfig.builder()
-                .signingSecret(signingSecret)
+                .signingSecret(signingSecretA)
                 .singleTeamBotToken(botTokenA)
                 .build();
 
         var app = new App(appConfig);
 
         app.event(com.slack.api.model.event.AppMentionEvent.class, (payload, context) -> {
-            // acknowledge the event so slack doesnt retry
             var ack = context.ack();
-
-            // process async
             CompletableFuture.runAsync(() -> {
                 try {
                     slackInboundAdapter.handle(payload.getEvent(), context);
@@ -53,33 +65,51 @@ public class SlackConfig {
                     // pass
                 }
             });
-
             return ack;
         });
 
-        // add slash command for closing incidents
+        // DM/actions registration for reporter bot
+        slackReporterFlow.register(app);
+
+        return app;
+    }
+
+    // Manager App (Bot B): handles incident management for developers
+    @Bean
+    public App managerSlackApp(SlackCloseIncident slackCloseIncident, SlackManagerActions slackManagerActions) {
+        var appConfig = AppConfig.builder()
+                .signingSecret(signingSecretB)
+                .singleTeamBotToken(botTokenB)
+                .build();
+
+        var app = new App(appConfig);
+
         app.command("/close_incident", (req, ctx) -> {
-            // process async
             CompletableFuture.runAsync(() -> {
                 try {
                     slackCloseIncident.handle(req, ctx);
-                    ctx.say("Incident noted! Thanks, we’ll look into it.");
                 } catch (Exception e) {
                     // pass
                 }
             });
-
             return ctx.ack("Processing incident closure...");
         });
+
+        // register manager actions (ack/dismiss/leave)
+        slackManagerActions.register(app);
 
         return app;
     }
 
     @Bean
-    public ServletRegistrationBean<Servlet> slackServlet(App app) {
-        return new ServletRegistrationBean<>(new SlackAppServlet(app), "/slack/events");
+    public ServletRegistrationBean<Servlet> reporterServlet(App reporterSlackApp) {
+        return new ServletRegistrationBean<>(new SlackAppServlet(reporterSlackApp), "/slack/reporter");
     }
 
+    @Bean
+    public ServletRegistrationBean<Servlet> managerServlet(App managerSlackApp) {
+        return new ServletRegistrationBean<>(new SlackAppServlet(managerSlackApp), "/slack/manager");
+    }
 
     @Bean
     public SlackCreateIncident slackIncomingAdapter(IncidentInboundPort incidentInboundPort) {
@@ -95,17 +125,51 @@ public class SlackConfig {
     public IncidentBroadcasterPort slackBroadcaster(
             @Value("${slack.botTokenB}") String botTokenB,
             @Value("${slack.developerUserId}") String developerUserId,
-            com.innovactions.incident.domain.service.ChannelNameGenerator channelNameGenerator
+            com.innovactions.incident.domain.service.ChannelNameGenerator channelNameGenerator,
+            BotMessagingPort managerBotMessagingPort,
+            ChannelAdministrationPort channelAdministrationPort
     ) {
-        return new SlackBroadcaster(botTokenB, developerUserId, channelNameGenerator);
+        return new SlackBroadcaster(botTokenB, developerUserId, channelNameGenerator, managerBotMessagingPort, channelAdministrationPort);
     }
 
     @Bean
     public IncidentClosurePort incidentClosureBroadcaster(
             @Value("${slack.botTokenB}") String botTokenB,
+            BotMessagingPort reporterBotMessagingPort,
+            BotMessagingPort managerBotMessagingPort,
+            ChannelAdministrationPort channelAdministrationPort
+    ) {
+        return new SlackIncidentClosureBroadcaster(botTokenB, reporterBotMessagingPort, managerBotMessagingPort, channelAdministrationPort);
+    }
+
+    @Bean
+    public SlackManagerActions slackManagerActions(
+            @Value("${slack.botTokenB}") String botTokenB,
+            ChannelAdministrationPort channelAdministrationPort,
+            BotMessagingPort managerBotMessagingPort
+    ) {
+        return new SlackManagerActions(botTokenB, channelAdministrationPort, managerBotMessagingPort);
+    }
+
+    @Bean
+    public BotMessagingPort reporterBotMessagingPort(
             @Value("${slack.botTokenA}") String botTokenA
     ) {
-        return new SlackIncidentClosureBroadcaster(botTokenB, botTokenA);
+        return new SlackBotMessagingAdapter(botTokenA);
+    }
+
+    @Bean
+    public BotMessagingPort managerBotMessagingPort(
+            @Value("${slack.botTokenB}") String botTokenB
+    ) {
+        return new SlackBotMessagingAdapter(botTokenB);
+    }
+
+    @Bean
+    public ChannelAdministrationPort channelAdministrationPort(
+            @Value("${slack.botTokenB}") String botTokenB
+    ) {
+        return new SlackChannelAdministrationAdapter(botTokenB);
     }
 
 }

--- a/src/main/java/com/innovactions/incident/config/properties/SlackProperties.java
+++ b/src/main/java/com/innovactions/incident/config/properties/SlackProperties.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "slack")
 public class SlackProperties {
-    private String signingSecret;
+    private String signingSecret; // legacy single-app support
+    private String signingSecretA;
+    private String signingSecretB;
     private String botTokenA;
     private String botTokenB;
     private String broadcastChannel;

--- a/src/main/java/com/innovactions/incident/port/outbound/BotMessagingPort.java
+++ b/src/main/java/com/innovactions/incident/port/outbound/BotMessagingPort.java
@@ -1,0 +1,9 @@
+package com.innovactions.incident.port.outbound;
+
+public interface BotMessagingPort {
+    void sendMessage(String channelId, String text);
+    void sendMessageWithBlocks(String channelId, String text, String blocksJson);
+    String resolveUserRealName(String userId);
+}
+
+

--- a/src/main/java/com/innovactions/incident/port/outbound/ChannelAdministrationPort.java
+++ b/src/main/java/com/innovactions/incident/port/outbound/ChannelAdministrationPort.java
@@ -1,0 +1,13 @@
+package com.innovactions.incident.port.outbound;
+
+import java.util.List;
+
+public interface ChannelAdministrationPort {
+    String createPublicChannel(String name);
+    void setChannelTopic(String channelId, String topic);
+    void inviteUsers(String channelId, List<String> userIds);
+    void kickUserFromChannel(String channelId, String userId);
+    List<String> listMembers(String channelId);
+}
+
+

--- a/src/main/java/com/innovactions/incident/port/outbound/IncidentClosurePort.java
+++ b/src/main/java/com/innovactions/incident/port/outbound/IncidentClosurePort.java
@@ -2,4 +2,5 @@ package com.innovactions.incident.port.outbound;
 
 public interface IncidentClosurePort {
     void closeIncident(String devId, String channelId, String reason);
+    void kickUserFromChannel(String channelId, String userId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ spring.application.name=incident-backend
 
 # Slack Configuration
 slack.signingSecret=${SLACK_SIGNING_SECRET}
+slack.signingSecretA=${SLACK_SIGNING_SECRET_A}
+slack.signingSecretB=${SLACK_SIGNING_SECRET_B}
 slack.botTokenA=${SLACK_BOT_TOKEN_A}
 slack.botTokenB=${SLACK_BOT_TOKEN_B}
 slack.broadcastChannel=${SLACK_BROADCAST_CHANNEL}


### PR DESCRIPTION
Added interactivity to the incident reporting flow using buttons in Slack workspace.

Added files in this commit:
- `PendingReportState.java` - The concurrent hashmap to store Slack user ID of users who reported incidents
- `SlackManagerActions.java` - Registers the Manager bot, shows actions that can be taken by the Manager bot
- `SlackReporterFlow.java` - Registers the Reporter bot, shows actions that can be taken by the Reporter bot
- `IncidentActionBlocks.java` - The JSON structure of our interactive buttons layout for bots
- `SlackBotMessagingAdapter.java` - Minimal class to send messages to Slack channels (Normal DM, DM with buttons, etc.)
- `SlackChannelAdministrationAdapter.java` - Class for channel administration (Create channel, set topic, invite/kick users)
- `BotMessagingPort.java` - Interface used to send messages to a Slack channel (`sendMessage`, `sendMessageWithBlocks`*)
- `ChannelAdministrationPort.java` - Interface used to create channels, perform actions on that channel

*Slack calls interactive buttons `Blocks`.

Other changes:
- Separated bots into their own instance (added `SlackRequestHandler` for each bot)
- Endpoint separation per bot, `/slack/reporter/{{ method }}` for `Reporter` bot and `/slack/manager/{{ method }}` for `Manager` bot
- Refactor most code to use the new ports and classes

> [!IMPORTANT]
> Both bots are now in the same workspace. There is the `Reporter` bot, which listens for incident reports from clients, and the `Manager` bot, which manages the incidents and listens to developer requests to resolve issues. **Each bot has its own instance**.

Expected flow:
1. Client sends a DM to the `Reporter` bot
2. `Reporter` replies with two buttons (`Report bug` and `Check status` - functionality not implemented yet)
3. Client clicks on `Report bug`
4. `Reporter` acknowledges and saves state (pending information) and asks for details of bug report
5. Client sends details of report in text format
6. `Reporter` bot saves details and categorizes incident and severity
7. `Manager` bot creates channel and invites developer into channel
8. Developer is presented with two buttons by `Manager` bot in the newly created channel (`Acknowledge` and `Dismiss incident`)
9. Developer clicks `Acknowledge`, developer works on incident
10. Developer finishes, issues `/close-incident` command and closes incident
11. `Reporter` bot was informed of resolved incident, informs the client that the issue has been resolved

### ⚠️ CAUTION
In order to run smoothly, please change Bot settings in Slack API platform:
1. `Incident Reporter Bot` - Change `Interactivity & Shortcuts` request URL to `{{ ngrok_url }}/slack/reporter`
2. `Incident Reporter Bot` - Change `Event Subscriptions` request URL to `{{ ngrok_url }}/slack/reporter`
3. `Incident Manager Bot` - Change `Interactivity & Shortcuts` request URL to `{{ ngrok_url }}/slack/manager`
4. `Incident Manager Bot` - Change `Slash Commands` `/close-incident` request URL to `{{ ngrok_url }}/slack/manager/close_incident`

Change according to your new Ngrok URL.